### PR TITLE
Give params.codebase_description a default value.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "spellbound",
       "version": "0.0.2",
+      "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.9",
         "ignore": "^5.2.4",

--- a/src/prompts/fillPrompt.ts
+++ b/src/prompts/fillPrompt.ts
@@ -37,6 +37,7 @@ export async function fillPrompt(params: FillPromptParams): Promise<string> {
   params.current_file_name = params.current_file_name || "undefined"
   params.langcode = params.langcode || "undefined"
   params.current_file_contents = params.current_file_contents || "undefined"
+  params.codebase_description = "Unknown codebase."
 
   const wsFolders = vscode.workspace.workspaceFolders
 
@@ -60,8 +61,6 @@ export async function fillPrompt(params: FillPromptParams): Promise<string> {
       vscode.window.showWarningMessage(
         "Could not find a .spellbound/description.md file in the workspace folder. Presence of this file improves AI performance."
       )
-
-      params.codebase_description = undefined
     }
   }
 


### PR DESCRIPTION
When using spellbound in a non-workspace environment, the default template throws an exception because params.codebase_description is not defined.